### PR TITLE
fix: Remove unrequired ddependency (urllib3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pandas==1.1.5
 requests==2.27.1
 dotenv==0.9.9
 shortuuid==1.0.13
-urllib3==*


### PR DESCRIPTION
We don't need urllib3 because "requests" library install this dependency.